### PR TITLE
Feat/create rev user without account

### DIFF
--- a/packages/destination-actions/src/destinations/devrev/createRevUser/index.ts
+++ b/packages/destination-actions/src/destinations/devrev/createRevUser/index.ts
@@ -172,11 +172,12 @@ const action: ActionDefinition<Settings, Payload> = {
       const tags = contact.tags?.map((tag) => tag.tag.id) ?? []
       if (tags.indexOf(payload.tag) === -1) {
         tags.push(payload.tag)
+        const formattedTags = tags.map((tag) => ({ id: tag }))
         await request(`${getBaseUrl(settings)}${devrevApiPaths.revUsersUpdate}`, {
           method: 'post',
           json: {
             id: contact.id,
-            tags
+            tags: formattedTags
           }
         })
       }

--- a/packages/destination-actions/src/destinations/devrev/createRevUser/index.ts
+++ b/packages/destination-actions/src/destinations/devrev/createRevUser/index.ts
@@ -3,7 +3,6 @@ import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { DynamicFieldResponse } from '@segment/actions-core'
 import {
-  AccountGet,
   AccountListResponse,
   RevOrgListResponse,
   RevUserGet,
@@ -11,10 +10,10 @@ import {
   TagsResponse,
   getDomain,
   devrevApiPaths,
-  CreateAccountBody,
   getName,
   getBaseUrl,
-  CreateRevUserBody
+  CreateRevUserBody,
+  RevUser
 } from '../utils'
 import { APIError } from '@segment/actions-core'
 
@@ -85,7 +84,7 @@ const action: ActionDefinition<Settings, Payload> = {
     },
     tag: {
       label: 'Tag',
-      description: 'A tag to apply to created Accounts.',
+      description: 'A tag to apply.',
       type: 'string',
       dynamic: true,
       required: false
@@ -124,65 +123,69 @@ const action: ActionDefinition<Settings, Payload> = {
     const existingUsers: RevUserListResponse = await request(
       `${getBaseUrl(settings)}${devrevApiPaths.revUsersList}?email="${email}"`
     )
-    let revUserId, accountId, revOrgId
+    let contact: RevUser | undefined = undefined
+
     if (existingUsers.data.rev_users.length == 0) {
       // No existing revusers, search for Account
-      let requestUrl
-      if (domain !== email) requestUrl = `${getBaseUrl(settings)}${devrevApiPaths.accountsList}?domains="${domain}"`
-      else requestUrl = `${getBaseUrl(settings)}${devrevApiPaths.accountsList}?external_refs="${domain}"`
-      const existingAccount: AccountListResponse = await request(requestUrl)
-      if (existingAccount.data.accounts.length == 0) {
-        // Create account
-        const requestBody: CreateAccountBody = {
-          display_name: domain,
-          external_refs: [domain]
-        }
-        if (payload.tag) requestBody.tags = [{ id: payload.tag }]
-        if (domain != email) requestBody.domains = [domain]
 
-        const createAccount: AccountGet = await request(`${getBaseUrl(settings)}${devrevApiPaths.accountCreate}`, {
-          method: 'post',
-          json: requestBody
-        })
-        accountId = createAccount.data.account.id
-      } else {
-        // Use existing account
-        accountId = existingAccount.data.accounts[0].id
-      }
-      const accountRevorgs: RevOrgListResponse = await request(
-        `${getBaseUrl(settings)}${devrevApiPaths.revOrgsList}?account=${accountId}`
-      )
-      const filtered = accountRevorgs.data.rev_orgs.filter(
-        (revorg) => revorg.external_ref_issuer == 'devrev:platform:revorg:account'
-      )
-      revOrgId = filtered[0].id
+      // Create the payload
       const createUserPayload: CreateRevUserBody = {
         email,
         display_name: name,
-        external_ref: email,
-        org_id: revOrgId
+        external_ref: email
       }
+
+      let requestUrl = ''
+      //Search using domain if the email domain is not blacklisted
+      // Otherwise search the external refs
+      if (domain !== email) requestUrl = `${getBaseUrl(settings)}${devrevApiPaths.accountsList}?domains="${domain}"`
+      else requestUrl = `${getBaseUrl(settings)}${devrevApiPaths.accountsList}?external_refs="${domain}"`
+      const existingAccount: AccountListResponse = await request(requestUrl)
+      if (existingAccount.data.accounts.length > 0) {
+        const accountId = existingAccount.data.accounts[0].id
+        const accountRevorgs: RevOrgListResponse = await request(
+          `${getBaseUrl(settings)}${devrevApiPaths.revOrgsList}?account=${accountId}`
+        )
+        const filtered = accountRevorgs.data.rev_orgs.filter(
+          (revorg) => revorg.external_ref_issuer == 'devrev:platform:revorg:account'
+        )
+        createUserPayload.org_id = filtered[0].id
+      }
+      // If there is a tag configured, apply it
       if (payload.tag) createUserPayload.tags = [{ id: payload.tag }]
       const createRevUser: RevUserGet = await request(`${getBaseUrl(settings)}${devrevApiPaths.revUsersCreate}`, {
         method: 'post',
         json: createUserPayload
       })
-      revUserId = createRevUser.data.rev_user.id
+      contact = createRevUser.data.rev_user
     } else if (existingUsers.data.rev_users.length == 1) {
       // One existing revuser
-      revUserId = existingUsers.data.rev_users[0].id
+      contact = existingUsers.data.rev_users[0]
     } else {
       // Multiple existing users, use the oldest one
       const sorted = existingUsers.data.rev_users.sort((a, b) => {
         return new Date(a.created_date).getTime() - new Date(b.created_date).getTime()
       })
-      revUserId = sorted[0].id
+      contact = sorted[0]
     }
-    if (payload.comment) {
+    if (payload.tag && contact) {
+      const tags = contact.tags?.map((tag) => tag.tag.id) ?? []
+      if (tags.indexOf(payload.tag) === -1) {
+        tags.push(payload.tag)
+        await request(`${getBaseUrl(settings)}${devrevApiPaths.revUsersUpdate}`, {
+          method: 'post',
+          json: {
+            id: contact.id,
+            tags
+          }
+        })
+      }
+    }
+    if (payload.comment && contact) {
       await request(`${getBaseUrl(settings)}${devrevApiPaths.timelineEntriesCreate}`, {
         method: 'post',
         json: {
-          object: revUserId,
+          object: contact.id,
           type: 'timeline_comment',
           body_type: 'text',
           body: payload.comment

--- a/packages/destination-actions/src/destinations/devrev/mocks/index.ts
+++ b/packages/destination-actions/src/destinations/devrev/mocks/index.ts
@@ -4,7 +4,12 @@ import * as types from '../utils/types'
 interface revUserCreateBody {
   email: string
   display_name: string
-  org_id: string
+  org_id?: string
+  tags?: { id: string }[]
+}
+
+interface revUserResponse {
+  rev_user: types.RevUser
 }
 
 export const accountId = 'test-account-id'
@@ -119,17 +124,41 @@ export const revUsersListResponse: types.RevUserListResponse = {
   }
 }
 
+export const revUsersSingleList: types.RevUserListResponse = {
+  data: {
+    rev_users: [testRevUserNewer]
+  }
+}
+
 export const revUsersCreateResponse = async (_: never, body: revUserCreateBody) => {
-  return {
+  const resp: revUserResponse = {
     rev_user: {
       id: testRevUserNewer.id,
       created_date: newerCreateDate,
       display_name: body.display_name,
-      email: body.email,
-      rev_org: {
-        id: body.org_id,
-        display_name: 'test-org'
-      }
+      email: body.email
+    }
+  }
+  if (body.org_id)
+    resp.rev_user.rev_org = {
+      id: body.org_id,
+      display_name: 'test-org'
+    }
+  if (body.tags) {
+    resp.rev_user.tags = body.tags.map((tag) => {
+      return { tag }
+    })
+  }
+  return resp
+}
+
+export const revUserUpdateTagsResponse = async (_: never, body: { id: string; tags: string[] }) => {
+  return {
+    rev_user: {
+      id: body.id,
+      tags: body.tags.map((tagid) => {
+        return { tag: { id: tagid } }
+      })
     }
   }
 }

--- a/packages/destination-actions/src/destinations/devrev/mocks/index.ts
+++ b/packages/destination-actions/src/destinations/devrev/mocks/index.ts
@@ -157,7 +157,7 @@ export const revUserUpdateTagsResponse = async (_: never, body: { id: string; ta
     rev_user: {
       id: body.id,
       tags: body.tags.map((tagid) => {
-        return { tag: { id: tagid } }
+        return { tag: tagid }
       })
     }
   }

--- a/packages/destination-actions/src/destinations/devrev/utils/constants.ts
+++ b/packages/destination-actions/src/destinations/devrev/utils/constants.ts
@@ -12,6 +12,7 @@ export const devrevApiPaths = {
   worksCreate: '/internal/works.create',
   accountCreate: '/internal/accounts.create',
   revUsersCreate: '/internal/rev-users.create',
+  revUsersUpdate: '/internal/rev-users.update',
   timelineEntriesCreate: '/timeline-entries.create',
   trackEventsPublish: '/internal/track-events.publish'
 }

--- a/packages/destination-actions/src/destinations/devrev/utils/types.ts
+++ b/packages/destination-actions/src/destinations/devrev/utils/types.ts
@@ -48,6 +48,11 @@ export interface RevUser extends IdFragment {
   created_date: string
   rev_org: IdFragment
   email: string
+  tags?: {
+    tag: {
+      id: string
+    }
+  }[]
 }
 
 export interface DevUser extends IdFragment {

--- a/packages/destination-actions/src/destinations/devrev/utils/types.ts
+++ b/packages/destination-actions/src/destinations/devrev/utils/types.ts
@@ -46,7 +46,7 @@ export interface RevOrg extends IdFragment {
 
 export interface RevUser extends IdFragment {
   created_date: string
-  rev_org: IdFragment
+  rev_org?: IdFragment
   email: string
   tags?: {
     tag: {


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Adding in one major feature and a few minor fixes:

1) RevUsers no longer need to be associated to an Account in our system, so createRevUsers now doesn't create an account.  Rather it tries to match an existing account by domain (respecting the blacklist) and if it doesn't find an account it just creates the RevUser by itself
2) Tags are now properly applied to RevUsers even if they already exist

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
